### PR TITLE
Update to use new RDir::read() API

### DIFF
--- a/BUBYFU.cpp
+++ b/BUBYFU.cpp
@@ -47,7 +47,7 @@ static void SignalHandler(int /*a_iSignal*/)
 	g_bBreak = true;
 }
 
-int main(int a_iArgC, const char *a_ppcArgV[])
+int main(int a_iArgC, char *a_ppcArgV[])
 {
 	char *Source, *Dest;
 	size_t Length;
@@ -61,7 +61,7 @@ int main(int a_iArgC, const char *a_ppcArgV[])
 
 	/* Parse the command line parameters passed in and make sure they are formatted correctly */
 
-	if ((Result = g_oArgs.open(g_accTemplate, ARGS_NUM_ARGS, a_ppcArgV, a_iArgC)) == KErrNone)
+	if ((Result = g_oArgs.open(g_accTemplate, ARGS_NUM_ARGS, a_iArgC, a_ppcArgV)) == KErrNone)
 	{
 		/* Open the scanner and allow it to parse the filter list if it exists.  It will display */
 		/* any errors required */

--- a/Scanner.cpp
+++ b/Scanner.cpp
@@ -1172,9 +1172,10 @@ int	RScanner::DeleteDir(const char *a_pccPath)
 
 	if ((RetVal = Dir.open(a_pccPath)) == KErrNone)
 	{
-		if ((RetVal = Dir.read(EntryArray)) == KErrNone)
+		if ((RetVal = Dir.read()) == KErrNone)
 		{
 			NextEntry = NULL;
+			EntryArray = Dir.getEntries();
 			Entry = EntryArray->getHead();
 
 			while (Entry)
@@ -1429,12 +1430,15 @@ int RScanner::Scan(char *a_pcSource, char *a_pcDest)
 	{
 		if ((RetVal = SourceDir.open(a_pcSource)) == KErrNone)
 		{
-			if ((RetVal = SourceDir.read(SourceEntries)) == KErrNone)
+			if ((RetVal = SourceDir.read()) == KErrNone)
 			{
+				SourceEntries = SourceDir.getEntries();
+
 				if ((RetVal = DestDir.open(a_pcDest)) == KErrNone)
 				{
-					if ((RetVal = DestDir.read(DestEntries)) == KErrNone)
+					if ((RetVal = DestDir.read()) == KErrNone)
 					{
+						DestEntries = DestDir.getEntries();
 						NextSource = NextDest = NULL;
 						Entry = SourceEntries->getHead();
 


### PR DESCRIPTION
The read() method is no longer passed a parameter into which to place a pointer to the entries array, so update its usage accordingly.